### PR TITLE
u-boot-solidrun-a38x: u-boot before v2018.05 requires patching.

### DIFF
--- a/recipes-bsp/u-boot/patches/0005-fw_env_main.c-Fix-incorrect-size-for-malloc-ed-strin.patch
+++ b/recipes-bsp/u-boot/patches/0005-fw_env_main.c-Fix-incorrect-size-for-malloc-ed-strin.patch
@@ -1,0 +1,28 @@
+From 17236152bf80436567bf3f1f27af3915364ec0b6 Mon Sep 17 00:00:00 2001
+From: Kristian Amlie <kristian.amlie@northern.tech>
+Date: Wed, 4 Apr 2018 10:01:04 +0200
+Subject: [PATCH 5/5] fw_env_main.c: Fix incorrect size for malloc'ed string.
+
+Using sizeof gives the size of the pointer only, not the string.
+
+Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
+---
+ tools/env/fw_env_main.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/env/fw_env_main.c b/tools/env/fw_env_main.c
+index 6fdf41c..f8e3f07 100644
+--- a/tools/env/fw_env_main.c
++++ b/tools/env/fw_env_main.c
+@@ -239,7 +239,7 @@ int main(int argc, char *argv[])
+ 	argv += optind;
+ 
+ 	if (env_opts.lockname) {
+-		lockname = malloc(sizeof(env_opts.lockname) +
++		lockname = malloc(strlen(env_opts.lockname) +
+ 				sizeof(CMD_PRINTENV) + 10);
+ 		if (!lockname) {
+ 			fprintf(stderr, "Unable allocate memory");
+-- 
+2.7.4
+

--- a/recipes-bsp/u-boot/u-boot-solidrun-a38x-common.inc
+++ b/recipes-bsp/u-boot/u-boot-solidrun-a38x-common.inc
@@ -11,7 +11,10 @@ PE = "1"
 SRCREV = "ab15b2d5b6ee50c106628dc0aa5943747a5dd772"
 SRCBRANCH = "v2018.01-solidrun-a38x"
 
+FILESEXTRAPATHS_prepend := "${THISDIR}/patches:"
+
 SRC_URI = "git://github.com/SolidRun/u-boot.git;branch=${SRCBRANCH}"
+SRC_URI_append = " file://0005-fw_env_main.c-Fix-incorrect-size-for-malloc-ed-strin.patch"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Fix coredump during uboot_auto_configure.

Reference:
- https://docs.mender.io/1.7/troubleshooting/yocto-project-build#do_mender_uboot_auto_configure-fails-when-executing-toolsenvfw_p

Signed-off-by: Cedric Veilleux <veilleux.cedric@gmail.com>